### PR TITLE
fix: rename IDLayer attribute

### DIFF
--- a/vortexasdk/api/shared_types.py
+++ b/vortexasdk/api/shared_types.py
@@ -42,7 +42,7 @@ class IDLayer:
     """Tuple containing `id` and `layer`."""
 
     id: ID
-    name: str
+    layer: str
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
changing attribute of `IDLayer` class from `name` -> `layer`