### PR TITLE
Remove fuzzy search

### DIFF
--- a/docs/examples/1_china.py
+++ b/docs/examples/1_china.py
@@ -24,7 +24,7 @@ china = [
 ]
 
 # Find the ID of all VLCCs
-vlccs = [v.id for v in Vessels().search(vessel_classes="vlcc_plus")]
+vlccs = [v.id for v in Vessels().search(vessel_classes="vlcc_plus").to_list()]
 
 # Query API
 search_result = CargoMovements().search(

--- a/docs/examples/1_china.py
+++ b/docs/examples/1_china.py
@@ -14,16 +14,26 @@ The below script returns:
 """
 from datetime import datetime
 
-from vortexasdk import CargoMovements
+from vortexasdk import CargoMovements, Geographies, Vessels
 
-df = (
-    CargoMovements()
-    .search(
-        filter_activity="loading_start",
-        filter_vessels="vlcc",
-        filter_destinations="China",
-        filter_time_min=datetime(2019, 8, 29),
-        filter_time_max=datetime(2019, 10, 30),
-    )
-    .to_df()
+# Find china ID
+china = [
+    g.id
+    for g in Geographies().search(term="china").to_list()
+    if "country" in g.layer
+]
+
+# Find the ID of all VLCCs
+vlccs = [v.id for v in Vessels().search(vessel_classes="vlcc_plus")]
+
+# Query API
+search_result = CargoMovements().search(
+    filter_activity="loading_start",
+    filter_vessels=vlccs,
+    filter_destinations=china,
+    filter_time_min=datetime(2019, 8, 29),
+    filter_time_max=datetime(2019, 10, 30),
 )
+
+# Convert search result to dataframe
+df = search_result.to_df()

--- a/docs/examples/2_all_vessel_movements.py
+++ b/docs/examples/2_all_vessel_movements.py
@@ -43,11 +43,12 @@ required_columns = [
     "vessel.corporate_entities.charterer.label",
     "vessel.corporate_entities.time_charterer.label",
     "vessel.corporate_entities.commercial_owner.label",
-    # Show the p
+    # Show the port, sts_zone, or vessel at the start of the vessel movement
     "origin.location.port.label",
     "origin.location.sts_zone.label",
     "origin.from_vessel.label",
     "origin.to_vessel.label",
+    # Show the port, sts_zone, or vessel at the end of the vessel movement
     "destination.location.port.label",
     "destination.location.sts_zone.label",
     "destination.from_vessel.label",

--- a/tests/api/test_cargo_movement.py
+++ b/tests/api/test_cargo_movement.py
@@ -1,7 +1,7 @@
-from typing import List
 from unittest import TestCase
 
 import jsons
+from typing import List
 
 from vortexasdk.api import (
     CargoEvent,
@@ -15,14 +15,6 @@ from vortexasdk.api.entity_flattening import (
     convert_cargo_movement_to_flat_dict,
 )
 from vortexasdk.api.serdes import serialize_to_dict
-from vortexasdk.api import (
-    CargoEvent,
-    CargoMovement,
-    CorporateEntity,
-    GeographyEntity,
-    ProductEntity,
-    VesselEntity,
-)
 
 
 class TestCargoMovement(TestCase):

--- a/tests/endpoints/test_cargo_movements_real.py
+++ b/tests/endpoints/test_cargo_movements_real.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from docs.utils import to_markdown
 from tests.testcases import TestCaseUsingRealAPI
 from tests.timer import Timer
+from vortexasdk import Geographies, Corporations
 from vortexasdk.endpoints.cargo_movements import CargoMovements
 
 
@@ -66,7 +67,11 @@ class TestCargoMovementsReal(TestCaseUsingRealAPI):
             CargoMovements()
             .search(
                 filter_activity="loading_state",
-                filter_origins="Rotterdam",
+                filter_origins=[
+                    g.id
+                    for g in Geographies().search(term="rotterdam").to_list()
+                    if "port" in g.layer
+                ],
                 filter_time_min=datetime(2019, 8, 29),
                 filter_time_max=datetime(2019, 8, 29, 0, 10),
             )
@@ -81,7 +86,9 @@ class TestCargoMovementsReal(TestCaseUsingRealAPI):
             CargoMovements()
             .search(
                 filter_activity="loading_state",
-                filter_owners="DHT",
+                filter_owners=[
+                    c.id for c in Corporations().search(term="DHT").to_list()
+                ],
                 filter_time_min=datetime(2018, 10, 1, 0),
                 filter_time_max=datetime(2018, 10, 5, 1),
             )
@@ -95,7 +102,9 @@ class TestCargoMovementsReal(TestCaseUsingRealAPI):
             CargoMovements()
             .search(
                 filter_activity="any_activity",
-                filter_waypoints="Suez",
+                filter_waypoints=[
+                    g.id for g in Geographies().search(term="suez").to_list()
+                ],
                 filter_time_min=datetime(2019, 8, 29),
                 filter_time_max=datetime(2019, 8, 29, 0, 10),
             )

--- a/tests/endpoints/test_geographies_real.py
+++ b/tests/endpoints/test_geographies_real.py
@@ -1,15 +1,9 @@
-from tests.testcases import TestCaseUsingRealAPI
 from docs.utils import to_markdown
+from tests.testcases import TestCaseUsingRealAPI
 from vortexasdk import Geographies
 
 
 class TestGeographiesReal(TestCaseUsingRealAPI):
-    def test_search(self):
-        geographies = Geographies().search(term=["Liverpool", "Southampton"])
-        names = [g["name"] for g in geographies]
-
-        assert "Liverpool [GB]" in names
-
     def test_load_all(self):
         all_geogs = Geographies().load_all()
 
@@ -24,3 +18,10 @@ class TestGeographiesReal(TestCaseUsingRealAPI):
         )
 
         print(to_markdown(geographies))
+
+    def test_search_to_list(self):
+        geographies = (
+            Geographies().search(term=["Liverpool", "Southampton"]).to_list()
+        )
+        names = [g.name for g in geographies]
+        assert "Liverpool [GB]" in names

--- a/tests/endpoints/test_vessel_movements_real.py
+++ b/tests/endpoints/test_vessel_movements_real.py
@@ -1,27 +1,37 @@
 from datetime import datetime
 
 from tests.testcases import TestCaseUsingRealAPI
-from vortexasdk import VesselMovements
+from vortexasdk import VesselMovements, Geographies
 from vortexasdk.endpoints import vessel_movements_result
 
 
 class TestVesselMovementsReal(TestCaseUsingRealAPI):
     def test_search(self):
+        rotterdam = [
+            g.id
+            for g in Geographies().search("rotterdam").to_list()
+            if "port" in g.layer
+        ]
         v = VesselMovements().search(
             filter_time_min=datetime(2017, 10, 1, 0, 0),
             filter_time_max=datetime(2017, 10, 1, 0, 10),
-            filter_origins="rotterdam",
+            filter_origins=rotterdam,
         )
 
         assert len(v) > 10
 
     def test_to_df_all_columns(self):
+        rotterdam = [
+            g.id
+            for g in Geographies().search("rotterdam").to_list()
+            if "port" in g.layer
+        ]
         df = (
             VesselMovements()
             .search(
                 filter_time_min=datetime(2017, 10, 1, 0, 0),
                 filter_time_max=datetime(2017, 10, 1, 0, 10),
-                filter_origins="rotterdam",
+                filter_origins=rotterdam,
             )
             .to_df(columns="all")
             .head(2)
@@ -30,12 +40,17 @@ class TestVesselMovementsReal(TestCaseUsingRealAPI):
         assert len(df) == 2
 
     def test_search_to_dataframe(self):
+        rotterdam = [
+            g.id
+            for g in Geographies().search("rotterdam").to_list()
+            if "port" in g.layer
+        ]
         df = (
             VesselMovements()
             .search(
                 filter_time_min=datetime(2017, 10, 1, 0, 0),
                 filter_time_max=datetime(2017, 10, 1, 0, 10),
-                filter_origins="rotterdam",
+                filter_origins=rotterdam,
             )
             .to_df()
             .head(2)
@@ -46,12 +61,18 @@ class TestVesselMovementsReal(TestCaseUsingRealAPI):
 
     def test_search_to_dataframe_subset_of_columns(self):
         cols = ["vessel.imo", "vessel.name"]
+
+        rotterdam = [
+            g.id
+            for g in Geographies().search("rotterdam").to_list()
+            if "port" in g.layer
+        ]
         df = (
             VesselMovements()
             .search(
                 filter_time_min=datetime(2017, 10, 1, 0, 0),
                 filter_time_max=datetime(2017, 10, 1, 0, 10),
-                filter_origins="rotterdam",
+                filter_origins=rotterdam,
             )
             .to_df(columns=cols)
             .head(2)

--- a/tests/endpoints/test_vessels_real.py
+++ b/tests/endpoints/test_vessels_real.py
@@ -1,5 +1,6 @@
 from tests.testcases import TestCaseUsingRealAPI
 from tests.timer import Timer
+from vortexasdk import Products
 from vortexasdk.endpoints.vessels import Vessels
 
 
@@ -31,8 +32,8 @@ class TestVesselsReal(TestCaseUsingRealAPI):
         aframax_called_zhen = set(
             v.id
             for v in Vessels()
-            .search(vessel_classes="aframax", term="zhen")
-            .to_list()
+                .search(vessel_classes="aframax", term="zhen")
+                .to_list()
         )
 
         assert aframax_called_zhen.issubset(aframax)
@@ -48,7 +49,8 @@ class TestVesselsReal(TestCaseUsingRealAPI):
         assert len(df) == 2
 
     def test_find_crude_vessels(self):
-        df = Vessels().search(vessel_product_types="crude").to_df()
+        crude = [p.id for p in Products().search("crude").to_list() if "group" in p.layer]
+        df = Vessels().search(vessel_product_types=crude).to_df()
         assert len(df) > 1000
 
     def test_load_all(self):

--- a/tests/endpoints/test_vessels_real.py
+++ b/tests/endpoints/test_vessels_real.py
@@ -32,8 +32,8 @@ class TestVesselsReal(TestCaseUsingRealAPI):
         aframax_called_zhen = set(
             v.id
             for v in Vessels()
-                .search(vessel_classes="aframax", term="zhen")
-                .to_list()
+            .search(vessel_classes="aframax", term="zhen")
+            .to_list()
         )
 
         assert aframax_called_zhen.issubset(aframax)
@@ -49,7 +49,11 @@ class TestVesselsReal(TestCaseUsingRealAPI):
         assert len(df) == 2
 
     def test_find_crude_vessels(self):
-        crude = [p.id for p in Products().search("crude").to_list() if "group" in p.layer]
+        crude = [
+            p.id
+            for p in Products().search("crude").to_list()
+            if "group" in p.layer
+        ]
         df = Vessels().search(vessel_product_types=crude).to_df()
         assert len(df) > 1000
 

--- a/vortexasdk/api/geography.py
+++ b/vortexasdk/api/geography.py
@@ -4,6 +4,7 @@ from typing import List, Optional, Tuple
 from vortexasdk.api.serdes import FromDictMixin
 from vortexasdk.api.shared_types import (
     EntityWithProbability,
+    ID,
     IDLayer,
     IDNameLayer,
     Node,
@@ -21,14 +22,17 @@ class BoundingBox:
 
 
 @dataclass(frozen=True)
-class Geography(Node, IDNameLayer, FromDictMixin):
+class Geography(Node, FromDictMixin):
     """Represent a Geography reference record returned by the API."""
 
-    bounding_box: Optional[BoundingBox]
-    centre_point: Optional[Position]
+    id: ID
+    name: str
+    layer: List[str]
     exclusion_rule: List[IDNameLayer]
     hierarchy: List[IDLayer]
-    location: Position
+    bounding_box: Optional[BoundingBox]
+    centre_point: Optional[Position]
+    location: Optional[Position]
 
 
 @dataclass(frozen=True)

--- a/vortexasdk/api/shared_types.py
+++ b/vortexasdk/api/shared_types.py
@@ -58,7 +58,7 @@ class IDNameLayer:
     """Triple holding `id`, `name`, and `layer`."""
 
     id: ID
-    layer: str
+    layer: List[str]
     name: str
 
 

--- a/vortexasdk/endpoints/cargo_movements.py
+++ b/vortexasdk/endpoints/cargo_movements.py
@@ -85,23 +85,23 @@ class CargoMovements(Search):
 
             cm_unit: Unit of measurement. Enter 'b' for barrels or 't' for tonnes.
 
-            filter_corporations: A corporation ID, or list of corporations to filter on.
+            filter_corporations: A corporation ID, or list of corporation IDs to filter on.
 
-            filter_destinations: A geography ID, or list of geographies to filter on.
+            filter_destinations: A geography ID, or list of geography IDs to filter on.
 
-            filter_origins: A geography ID, or list of geographies to filter on.
+            filter_origins: A geography ID, or list of geography IDs to filter on.
 
-            filter_owners: An owner ID, or list of owners to filter on.
+            filter_owners: An owner ID, or list of owner IDs to filter on.
 
-            filter_products: A product ID, or list of products to filter on.
+            filter_products: A product ID, or list of product IDs to filter on.
 
-            filter_vessels: A vessel ID, or list of vessels to filter on.
+            filter_vessels: A vessel ID, or list of vessel IDs to filter on.
 
-            filter_storage_locations: A geography ID, or list of geography to filter on.
+            filter_storage_locations: A geography ID, or list of geography IDs to filter on.
 
-            filter_ship_to_ship_locations: A geography ID, or list of geography to filter on.
+            filter_ship_to_ship_locations: A geography ID, or list of geography IDs to filter on.
 
-            filter_waypoints: A geography ID, or list of geography to filter on.
+            filter_waypoints: A geography ID, or list of geography IDs to filter on.
 
             disable_geographic_exclusion_rules: This controls a popular industry term "intra-movements" and determines
              the filter behaviour for cargo leaving then entering the same geographic area.

--- a/vortexasdk/endpoints/cargo_movements.py
+++ b/vortexasdk/endpoints/cargo_movements.py
@@ -116,7 +116,7 @@ class CargoMovements(Search):
 
 
         ```python
-        >>> from vortexasdk import CargoMovements
+        >>> from vortexasdk import CargoMovements, Geographies
         >>> rotterdam = [g.id for g in Geographies().search("rotterdam").to_list() if "port" in g.layer]
         >>> search_result = CargoMovements().search(
         ...    filter_origins=rotterdam,
@@ -145,7 +145,7 @@ class CargoMovements(Search):
         >>> from vortexasdk import CargoMovements, Geographies, Vessels
         >>> suez = [g.id for g in Geographies().search("suez").to_list()]
         >>> china = [g.id for g in Geographies().search("china").to_list() if "country" in g.layer]
-        >>> vlccs = [v.id for v in Vessels().search(vessel_classes="vlcc_plus")]
+        >>> vlccs = [v.id for v in Vessels().search(vessel_classes="vlcc_plus").to_list()]
         >>> cargo_movement_search_result = CargoMovements().search(
         ...    filter_destinations=china,
         ...    filter_activity="loading_state",

--- a/vortexasdk/endpoints/cargo_movements.py
+++ b/vortexasdk/endpoints/cargo_movements.py
@@ -2,22 +2,17 @@
 from datetime import datetime
 from typing import List, Union
 
-from vortexasdk.logger import get_logger
-
+from vortexasdk.api import ID
 from vortexasdk.api.shared_types import to_ISODate
 from vortexasdk.config import (
-    END_OF_AVAILABLE_DATA,
     BEGINNING_OF_AVAILABLE_DATA,
-)
-from vortexasdk.conversions import (
-    convert_to_corporation_ids,
-    convert_to_geography_ids,
-    convert_to_product_ids,
-    convert_to_vessel_ids,
+    END_OF_AVAILABLE_DATA,
 )
 from vortexasdk.endpoints.cargo_movements_result import CargoMovementsResult
 from vortexasdk.endpoints.endpoints import CARGO_MOVEMENTS_RESOURCE
+from vortexasdk.logger import get_logger
 from vortexasdk.operations import Search
+from vortexasdk.utils import convert_to_list
 
 logger = get_logger(__name__)
 
@@ -50,7 +45,6 @@ class CargoMovements(Search):
         """
         logger.info(
             f"Loading all Cargo Movements between {BEGINNING_OF_AVAILABLE_DATA} and {END_OF_AVAILABLE_DATA},"
-            f" this will take 5-10mins."
         )
         return self.search(
             filter_activity="loading_start",
@@ -64,15 +58,15 @@ class CargoMovements(Search):
         filter_time_min: datetime = datetime(2019, 10, 1, 0),
         filter_time_max: datetime = datetime(2019, 10, 1, 1),
         cm_unit: str = "b",
-        filter_charterers: Union[str, List[str]] = None,
-        filter_destinations: Union[str, List[str]] = None,
-        filter_origins: Union[str, List[str]] = None,
-        filter_owners: Union[str, List[str]] = None,
-        filter_products: Union[str, List[str]] = None,
-        filter_vessels: Union[str, List[str]] = None,
-        filter_storage_locations: Union[str, List[str]] = None,
-        filter_ship_to_ship_locations: Union[str, List[str]] = None,
-        filter_waypoints: Union[str, List[str]] = None,
+        filter_charterers: Union[ID, List[ID]] = None,
+        filter_destinations: Union[ID, List[ID]] = None,
+        filter_origins: Union[ID, List[ID]] = None,
+        filter_owners: Union[ID, List[ID]] = None,
+        filter_products: Union[ID, List[ID]] = None,
+        filter_vessels: Union[ID, List[ID]] = None,
+        filter_storage_locations: Union[ID, List[ID]] = None,
+        filter_ship_to_ship_locations: Union[ID, List[ID]] = None,
+        filter_waypoints: Union[ID, List[ID]] = None,
         disable_geographic_exclusion_rules: bool = None,
     ) -> CargoMovementsResult:
         """
@@ -91,23 +85,23 @@ class CargoMovements(Search):
 
             cm_unit: Unit of measurement. Enter 'b' for barrels or 't' for tonnes.
 
-            filter_corporations: A corporation, or list of corporations to filter on.
+            filter_corporations: A corporation ID, or list of corporations to filter on.
 
-            filter_destinations: A geography, or list of geographies to filter on. Both geography names or IDs can be entered here.
+            filter_destinations: A geography ID, or list of geographies to filter on.
 
-            filter_origins: A geography, or list of geographies to filter on. Both geography names or IDs can be entered here.
+            filter_origins: A geography ID, or list of geographies to filter on.
 
-            filter_owners: An owner, or list of owners to filter on. Both charterer/owner names or IDs can be entered here.
+            filter_owners: An owner ID, or list of owners to filter on.
 
-            filter_products: A product, or list of products to filter on. Both product names or IDs can be entered here.
+            filter_products: A product ID, or list of products to filter on.
 
-            filter_vessels: A vessel, or list of vessels to filter on. Vessel name, imo, mmsi, vessel class, or vessel IDs can be entered here,
+            filter_vessels: A vessel ID, or list of vessels to filter on.
 
-            filter_storage_locations: A geography, or list of geography to filter on. Both geography names or IDs can be entered here.
+            filter_storage_locations: A geography ID, or list of geography to filter on.
 
-            filter_ship_to_ship_locations: A geography, or list of geography to filter on. Both geography names or IDs can be entered here.
+            filter_ship_to_ship_locations: A geography ID, or list of geography to filter on.
 
-            filter_waypoints: A geography, or list of geography to filter on. Both geography names or IDs can be entered here.
+            filter_waypoints: A geography ID, or list of geography to filter on.
 
             disable_geographic_exclusion_rules: This controls a popular industry term "intra-movements" and determines
              the filter behaviour for cargo leaving then entering the same geographic area.
@@ -122,9 +116,10 @@ class CargoMovements(Search):
 
 
         ```python
-        >>> from vortexasdk import CargoMovements
+        >>> from vortexasdk import CargoMovements, Geographies
+        >>> rotterdam = [g.id for g in Geographies().search("rotterdam").to_list() if "port" in g.layer]
         >>> df = CargoMovements().search(
-            filter_origins="Rotterdam",
+            filter_origins=rotterdam,
             filter_activity='loading_state',
             filter_time_min=datetime(2018, 12, 1),
             filter_time_max=datetime(2018, 12, 1, 12),
@@ -147,14 +142,17 @@ class CargoMovements(Search):
         This lets us view all vessels present in any STS operations.
 
         ```python
-        >>> from vortexasdk import CargoMovements
+        >>> from vortexasdk import CargoMovements, Geographies, Vessels
+        >>> suez = [g.id for g in Geographies().search("suez").to_list()]
+        >>> china = [g.id for g in Geographies().search("china").to_list() if "country" in g.layer]
+        >>> vlccs = [v.id for v in Vessels().search(vessel_classes="vlcc_plus")]
         >>> cols = ['vessels.0.name', 'vessels.0.vessel_class', 'vessels.1.name', 'vessels.1.vessel_class',  'vessels.2.name', 'vessels.2.vessel_class', 'product.group.label', 'quantity']
 
         >>> df = CargoMovements().search(
-            filter_destinations="China",
+            filter_destinations=china,
             filter_activity="loading_state",
-            filter_waypoints="suez",
-            filter_vessels="vlcc",
+            filter_waypoints=suez,
+            filter_vessels=vlccs,
             filter_time_min=datetime(2016, 12, 01),
             filter_time_max=datetime(2018, 12, 01),
         ).to_df(columns=cols)
@@ -179,21 +177,19 @@ class CargoMovements(Search):
             "filter_time_max": to_ISODate(filter_time_max),
             "cm_unit": cm_unit,
             "size": self._MAX_PAGE_RESULT_SIZE,
-            "filter_charterers": convert_to_corporation_ids(filter_charterers),
-            "filter_owners": convert_to_corporation_ids(filter_owners),
-            "filter_products": convert_to_product_ids(filter_products),
-            "filter_vessels": convert_to_vessel_ids(filter_vessels),
-            "filter_destinations": convert_to_geography_ids(
-                filter_destinations
-            ),
-            "filter_origins": convert_to_geography_ids(filter_origins),
-            "filter_storage_locations": convert_to_geography_ids(
+            "filter_charterers": convert_to_list(filter_charterers),
+            "filter_owners": convert_to_list(filter_owners),
+            "filter_products": convert_to_list(filter_products),
+            "filter_vessels": convert_to_list(filter_vessels),
+            "filter_destinations": convert_to_list(filter_destinations),
+            "filter_origins": convert_to_list(filter_origins),
+            "filter_storage_locations": convert_to_list(
                 filter_storage_locations
             ),
-            "filter_ship_to_ship_locations": convert_to_geography_ids(
+            "filter_ship_to_ship_locations": convert_to_list(
                 filter_ship_to_ship_locations
             ),
-            "filter_waypoints": convert_to_geography_ids(filter_waypoints),
+            "filter_waypoints": convert_to_list(filter_waypoints),
             "disable_geographic_exclusion_rules": disable_geographic_exclusion_rules,
         }
 

--- a/vortexasdk/endpoints/geographies.py
+++ b/vortexasdk/endpoints/geographies.py
@@ -35,7 +35,7 @@ class Geographies(Reference, Search):
         Find all geographies with `portsmouth` in the name.
         ```python
         >>> from vortexasdk import Geographies
-        >>> [x["name"] for x in Geographies().search(term="portsmouth")]
+        >>> [g.name for g in Geographies().search(term="portsmouth").to_list()]
             ['Portsmouth [GB]', 'Portsmouth, NH [US]']
         ```
 

--- a/vortexasdk/endpoints/vessel_movements.py
+++ b/vortexasdk/endpoints/vessel_movements.py
@@ -54,7 +54,6 @@ class VesselMovements(Search):
         """
         logger.info(
             f"Loading all Vessel Movements between {BEGINNING_OF_AVAILABLE_DATA} and {END_OF_AVAILABLE_DATA},"
-            f" this will take 5-10mins."
         )
 
         return self.search(

--- a/vortexasdk/endpoints/vessel_movements.py
+++ b/vortexasdk/endpoints/vessel_movements.py
@@ -2,22 +2,14 @@
 from datetime import datetime
 from typing import List, Union
 
-from vortexasdk.logger import get_logger
-
 from vortexasdk.api.shared_types import to_ISODate
 from vortexasdk.config import (
     BEGINNING_OF_AVAILABLE_DATA,
     END_OF_AVAILABLE_DATA,
 )
-
-from vortexasdk.conversions import (
-    convert_to_corporation_ids,
-    convert_to_geography_ids,
-    convert_to_product_ids,
-    convert_to_vessel_ids,
-)
 from vortexasdk.endpoints.endpoints import VESSEL_MOVEMENTS_RESOURCE
 from vortexasdk.endpoints.vessel_movements_result import VesselMovementsResult
+from vortexasdk.logger import get_logger
 from vortexasdk.operations import Search
 from vortexasdk.utils import convert_to_list
 
@@ -49,7 +41,8 @@ class VesselMovements(Search):
 
         ```python
         >>> from vortexasdk import VesselMovements
-        >>> df = VesselMovements().load_all().to_df()
+        >>> df = VesselMovements().load_all().to_df() # doctest:+SKIP
+
         ```
         """
         logger.info(
@@ -84,19 +77,19 @@ class VesselMovements(Search):
 
             unit: Unit of measurement. Enter 'b' for barrels or 't' for tonnes.
 
-            filter_corporations: A corporation, or list of corporations to filter on.
+            filter_corporations: A corporation ID, or list of corporation IDs to filter on.
 
-            filter_destinations: A geography, or list of geographies to filter on. Both geography names or IDs can be entered here.
+            filter_destinations: A geography ID, or list of geography IDs to filter on.
 
-            filter_origins: A geography, or list of geographies to filter on. Both geography names or IDs can be entered here.
+            filter_origins: A geography ID, or list of geography IDs to filter on.
 
-            filter_owners: An owner, or list of owners to filter on. Both charterer/owner names or IDs can be entered here.
+            filter_owners: An corporation ID, or list of corporation IDs to filter on.
 
-            filter_products: A product, or list of products to filter on. Both product names or IDs can be entered here.
+            filter_products: A product ID, or list of product IDs to filter on.
 
-            filter_vessels: A vessel, or list of vessels to filter on. Both vessel names or IDs can be entered here,
+            filter_vessels: A vessel ID, or list of vessel IDs to filter on.
 
-            filter_vessel_classes: A vessel class, or list of vessel classes to filter on. Both vessel names or IDs can be entered here,
+            filter_vessel_classes: A vessel class, or list of vessel classes to filter on.
 
         # Returns
         `VesselMovementsResult`, containing all the vessel movements matching the given search terms.
@@ -106,12 +99,14 @@ class VesselMovements(Search):
         Let's search for all vessels that departed from `Rotterdam [NL]` on the morning of 1st December 2018.
 
         ```python
-        >>> from vortexasdk import VesselMovements
+        >>> from vortexasdk import VesselMovements, Geographies
+        >>> rotterdam = [g.id for g in Geographies().search("rotterdam").to_list() if "port" in g.layer]
         >>> df = VesselMovements().search(
-                filter_time_min=datetime(2017, 10, 1, 0, 0),
-                filter_time_max=datetime(2017, 10, 1, 0, 10),
-                filter_origins='rotterdam'
-        ).to_df().head(2)
+        ...        filter_time_min=datetime(2017, 10, 1, 0, 0),
+        ...        filter_time_max=datetime(2017, 10, 1, 0, 10),
+        ...        filter_origins=rotterdam
+        ... ).to_df().head(2)
+
         ```
 
         |    | start_timestamp          | end_timestamp            |   vessel.imo | vessel.name   | vessel.vessel_class   | origin.location.country.label   | origin.location.port.label   | destination.location.country.label   | destination.location.port.label   |   cargoes.0.quantity | cargoes.0.product.grade.label   |
@@ -123,21 +118,16 @@ class VesselMovements(Search):
 
         """
         params = {
-            # Compulsory search parameters
             "filter_time_min": to_ISODate(filter_time_min),
             "filter_time_max": to_ISODate(filter_time_max),
             "unit": unit,
             "size": self._MAX_PAGE_RESULT_SIZE,
-            "filter_charterers": convert_to_corporation_ids(filter_charterers),
-            "filter_owners": convert_to_corporation_ids(filter_owners),
-            "filter_destinations": convert_to_geography_ids(
-                filter_destinations
-            ),
-            "filter_origins": convert_to_geography_ids(filter_origins),
-            "filter_products": convert_to_product_ids(filter_products),
-            "filter_vessels": convert_to_vessel_ids(
-                convert_to_list(filter_vessels)
-            ),
+            "filter_charterers": convert_to_list(filter_charterers),
+            "filter_owners": convert_to_list(filter_owners),
+            "filter_destinations": convert_to_list(filter_destinations),
+            "filter_origins": convert_to_list(filter_origins),
+            "filter_products": convert_to_list(filter_products),
+            "filter_vessels": convert_to_list(filter_vessels),
             "filter_vessel_classes": convert_to_list(filter_vessel_classes),
         }
 

--- a/vortexasdk/endpoints/vessels.py
+++ b/vortexasdk/endpoints/vessels.py
@@ -25,7 +25,7 @@ class Vessels(Reference, Search):
         term: Union[str, List[str]] = None,
         ids: Union[str, List[str]] = None,
         vessel_classes: Union[str, List[str]] = None,
-        vessel_product_types: Union[str, List[str]] = None,
+        vessel_product_types: Union[ID, List[ID]] = None,
     ) -> VesselsResult:
         """
         Find all vessels matching given search arguments. Search arguments are combined in an AND manner.
@@ -37,7 +37,7 @@ class Vessels(Reference, Search):
 
             vessel_classes: vessel_class (or list of vessel classes) we'd like to search. Each vessel class must be one of "tiny_tanker" , "general_purpose" , "handysize" , "handymax" , "panamax" , "aframax" , "suezmax" , "vlcc_plus" , "sgc" , "mgc" , "lgc" , "vlgc". Refer to [ VortexaAPI Vessel Entities](https://docs.vortexa.com/reference/intro-vessel-entities) for the most up-to-date list of vessel classes.
 
-            vessel_product_types: A product, or list of products to filter on, searching vessels currently carrying these products. Both product names or IDs can be entered here.
+            vessel_product_types: A product ID, or list of product IDs to filter on, searching vessels currently carrying these products.
 
         # Returns
         List of vessels matching the search arguments.

--- a/vortexasdk/endpoints/vessels.py
+++ b/vortexasdk/endpoints/vessels.py
@@ -2,7 +2,6 @@
 from typing import List, Union, Dict
 
 from vortexasdk.api.id import ID
-from vortexasdk.conversions import convert_to_product_ids
 from vortexasdk.endpoints.endpoints import VESSELS_REFERENCE
 from vortexasdk.endpoints.vessels_result import VesselsResult
 from vortexasdk.operations import Reference, Search
@@ -51,8 +50,8 @@ class Vessels(Reference, Search):
         ```python
         >>> from vortexasdk import Vessels
         >>> Vessels().search(vessel_classes='vlcc', term='ocean').to_df(columns=['name', 'imo', 'mmsi', 'related_names'])
+        ...
         ```
-
         |    | name         |     imo |      mmsi | related_names             |
         |---:|:-------------|--------:|----------:|:--------------------------|
         |  0 | OCEANIS      | 9532757 | 241089000 | ['OCEANIS']               |
@@ -70,7 +69,9 @@ class Vessels(Reference, Search):
         - Let's find all the vessels currently carrying Crude.
 
         ```python
-        >>> Vessels().search(vessel_product_types='crude').to_df()
+        >>> from vortexasdk import Vessels, Products
+        >>> crude = [p.id for p in Products().search(term="crude").to_list() if 'group' in p.layer]
+        >>> Vessels().search(vessel_product_types=crude).to_df()
         ```
 
         # Further Documentation
@@ -82,9 +83,7 @@ class Vessels(Reference, Search):
             "term": [str(e) for e in convert_to_list(term)],
             "ids": convert_to_list(ids),
             "vessel_classes": convert_to_list(vessel_classes),
-            "vessel_product_types": convert_to_product_ids(
-                convert_to_list(vessel_product_types)
-            ),
+            "vessel_product_types": convert_to_list(vessel_product_types),
         }
 
         return VesselsResult(super().search(**search_params))


### PR DESCRIPTION
Enforce strict searching by IDs, removing the problem where a user would search for "India", and receive "Indiana", "British Indian Territories", "India"... etc.

We'll reintroduce fuzzy searching in a different PR under a different method (`fuzzy_search`) that can be used for exploratory analysis.